### PR TITLE
Add azure identity package

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -26,3 +26,4 @@ requests==2.31.0
 sentry-sdk==1.22.2
 urllib3==1.26.16
 xmltodict==0.13.0
+azure-identity==1.14.0


### PR DESCRIPTION
This is required for ETL processes to authenticate against AAD with their Workload Identity in order to aquire short lived tokens to write to the database